### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+python:
+  - 3.6
+  - 3.5
+  - 3.4
+  - 2.7
+
+# Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install -U tox-travis
+
+# Command to run tests, e.g. python setup.py test
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 ``filehash``
 ============
 
+.. image:: https://img.shields.io/pypi/v/filehash.svg
+        :target: https://pypi.python.org/pypi/filehash
+
+.. image:: https://img.shields.io/travis/mmore500/keyname.svg
+        :target: https://travis-ci.org/mmore500/keyname
+
 Python module to facilitate calculating the checksum or hash of a file.  Tested against Python 2.7, Python 3.6, PyPy 2.7 and PyPy 3.5.  Currently supports `Adler-32 <https://en.wikipedia.org/wiki/Adler-32>`_, `CRC32 <https://en.wikipedia.org/wiki/Cyclic_redundancy_check>`_, `MD5 <https://en.wikipedia.org/wiki/MD5>`_, `SHA-1 <https://en.wikipedia.org/wiki/SHA-1>`_, `SHA-256 and SHA-512 <https://en.wikipedia.org/wiki/SHA-2>`_.
 
 ``FileHash`` class


### PR DESCRIPTION
I added Travis CI testing and badges to the `README.rst` (Travis and PyPi). You can check out the badges on the master branch of my fork [https://github.com/mmore500/filehash](https://github.com/mmore500/filehash). If you merge this in, you'll want to go to [travis-ci.org](travis-ci.org) and activate the service for this repo. Then, you'll want to change the URL for the badge in the `README.rst` to refer to your username, not mine (mmore500).

It should just take a few minutes, but I figured I'd make this a separate PR in case you thought getting this set up would be more trouble than it's worth.