### PR TITLE
Add support for user specified blocksize and increase default to 8192

### DIFF
--- a/filehash/filehash.py
+++ b/filehash/filehash.py
@@ -149,7 +149,7 @@ class FileHash:
     Class wrapping the hashlib module to facilitate calculating file hashes.
     """
 
-    def __init__(self, hash_algorithm='sha256', chunk_size=4096):
+    def __init__(self, hash_algorithm='sha256', chunk_size=8192):
         """
         Initialize the FileHash class.
 
@@ -164,6 +164,7 @@ class FileHash:
         if hash_algorithm not in SUPPORTED_ALGORITHMS:
             raise ValueError("Error, unsupported hash/checksum algorithm: {0}".format(hash_algorithm))
         self.chunk_size = chunk_size
+        # print("FileHash:INIT: chunk_size =", self.chunk_size)
         self.hash_algorithm = hash_algorithm
 
     def hash_file(self, filename):

--- a/filehash/filehash_cli.py
+++ b/filehash/filehash_cli.py
@@ -6,7 +6,7 @@ from filehash import FileHash, SUPPORTED_ALGORITHMS
 
 
 default_hash_algorithm = 'sha256'
-
+default_chunk_size = 8192
 def create_parser():
     parser = argparse.ArgumentParser(
         description="Tool for calculating the checksum / hash of a file or directory."
@@ -19,6 +19,15 @@ def create_parser():
             default_hash_algorithm
         ),
         default=default_hash_algorithm
+    )
+    parser.add_argument(
+        u"-b",
+        u"--blocksize",
+        type=int,
+        help=u"Blocksize/ChunkSize for hash algorithm to use.  Valid values are multiples of 4096.  Defaults to \"{0}\"".format(
+            default_chunk_size
+        ),
+        default=default_chunk_size
     )
 
     parser_group = parser.add_mutually_exclusive_group(required=True)
@@ -95,7 +104,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    hasher = FileHash(args.algorithm.lower())
+    hasher = FileHash(args.algorithm.lower(), args.blocksize)
     if args.checksums:
         process_checksum_file(args.checksums, hasher)
     elif args.directory:


### PR DESCRIPTION
Module is very useful, thanks!  I found myself wanting better performance.  For larger files increasing block-size significantly improves performance.  Adding command line flag and parameter let's users specify block-size without rebuilding code.  I found no measurable performance hit using 8K reads of 4k files (read just returns amount read); however larger block-size on large files significantly improved performance.  Most modern drives drive prefetch in larger blocks (SSD) and filesystems often define larger block-sizes.  I am less wedded to the default size change, than I am adding the command line option.